### PR TITLE
Add option to import package through Unity Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-*.meta
 .DS_Store

--- a/Chat.cs.meta
+++ b/Chat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfa1bd79ef604394e9dec016f1c8a2b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChatGPTConversation.cs.meta
+++ b/ChatGPTConversation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd863684a93292844b47a08ec0809828
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ChatGPTWrapper.asmdef
+++ b/ChatGPTWrapper.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "ChatGPTWrapper"
+}

--- a/ChatGPTWrapper.asmdef.meta
+++ b/ChatGPTWrapper.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e2dd40b6c1f59ce4aa07be2b237fc5ee
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48e67fbffe5546a478b00abaffd1333e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ChatGPTEditor.cs.meta
+++ b/Editor/ChatGPTEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a10d5baffc0044b49afa601a4188bb93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ChatGPTWrapper.Editor.asmdef
+++ b/Editor/ChatGPTWrapper.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "ChatGPTWrapper.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:e2dd40b6c1f59ce4aa07be2b237fc5ee"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/ChatGPTWrapper.Editor.asmdef.meta
+++ b/Editor/ChatGPTWrapper.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3cb7f3aa65ec2ca489aa8ebe8f77ead3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GenericUnityEvents.cs.meta
+++ b/GenericUnityEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53fd5614b7a894e4b80c932064c8ab02
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 725f609703bc3e14b9734f38397a272c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Prompt.cs.meta
+++ b/Prompt.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5316b1f3b2c8493488fe4b621d1f79e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ In its current state, this wrapper is not suitable for production use. If you sh
 
 ## Guide
 1. Either download the zip and extract it into an existing Unity project, or clone the repo into your project's Assets directory. <br>
-  If you are using a version of Unity that does not support Unity's UI Toolkit, you can just delete the whole UI folder as it's not required.
+  If you are using a version of Unity that does not support Unity's UI Toolkit, you can just delete the whole UI folder as it's not required. <br>
+  Also you can import package using **Unity Package Manager** (**Add package from Git URL** - https://github.com/GraesonB/ChatGPT-Wrapper-For-Unity.git) or just add "com.graesonb.chat-gpt-wrapper-for-unity": "https://github.com/GraesonB/ChatGPT-Wrapper-For-Unity.git" to **Packages/manifest.json**
 
 2. Create an empty game object, and add the "ChatGPTConversation" script to it.
 ![Screenshot 2023-03-01 at 8 41 26 PM](https://user-images.githubusercontent.com/89364458/222325449-47a833a6-9f10-4583-a78d-69aef54b7e3d.png)

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c9a073ff786c6284394dee28ebe007c2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Requests.cs.meta
+++ b/Requests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43217bbb6cb2cf04b82fa9b5bd2b5a14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UI.meta
+++ b/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 027c589cc458ab348b8b26d647a03194
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UI/UI.cs.meta
+++ b/UI/UI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24f97f643c7f6c84eb5995a31c2787d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UI/UI.uxml.meta
+++ b/UI/UI.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1d29f2cf2ce013b4a95f48365b74c865
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/UI/styles.uss.meta
+++ b/UI/styles.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3ac6910032813243ad2e89db9d9a8d6
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/WebRequestClasses.meta
+++ b/WebRequestClasses.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4453d735d2cd30469f178df5e8956f8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/ChatGPTChoices.cs.meta
+++ b/WebRequestClasses/ChatGPTChoices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3667cb8d017e65d4b95211afe0cd96f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/ChatGPTReq.cs.meta
+++ b/WebRequestClasses/ChatGPTReq.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 026dedab64498df419c065d5f85208f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/ChatGPTRes.cs.meta
+++ b/WebRequestClasses/ChatGPTRes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c1622b38c251e84aba7c16373bc941f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/GPTChoices.cs.meta
+++ b/WebRequestClasses/GPTChoices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39e5bce6b090d814691c9f0c55c2f8e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/GPTReq.cs.meta
+++ b/WebRequestClasses/GPTReq.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 257101d86a48d54459bd3f86cac69565
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/GPTRes.cs.meta
+++ b/WebRequestClasses/GPTRes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70577af3ba602c045899845955e9b9cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/GPTResError.cs.meta
+++ b/WebRequestClasses/GPTResError.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a9adc03bd958040969180ecc6367d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WebRequestClasses/Message.cs.meta
+++ b/WebRequestClasses/Message.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf7f2919dffa1f14aba64e6a5b34153b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+﻿{
+  "name": "com.graesonb.chat-gpt-wrapper-for-unity",
+  "version": "0.1.0",
+  "displayName": "ChatGPT Wrapper For Unity"
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8ac85a6ec1c92d049a852b2eb49ab58d
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hello!

Using [Unity Package Manager](https://docs.unity3d.com/Manual/upm-ui.html) now is a standard way to import external code.  
Here is the basic implementation of such an option.

Please note that in the testing process, you need to use the git URL to my fork before merging to get the package imported - https://github.com/KonH/ChatGPT-Wrapper-For-Unity.git. I put your URL in the readme but it started to work after the merge.

Also, I found two issues with that approach:
- .meta files are important for UPM packages, please look at commit - https://github.com/GraesonB/ChatGPT-Wrapper-For-Unity/commit/3001af4bed3d17611e6c8ede9ec06919df8de620
- Now I see error in the editor considering UI Toolkit:
```
Packages/com.graesonb.chat-gpt-wrapper-for-unity/UI/UI.uxml (2,6): Semantic - The specified URI does not exist in the current project : project://database/Assets/ChatGPT-Wrapper-For-Unity/UI/styles.uss?fileID=7433441132597879392&guid=b8b43e675b4894245bde99ef6166a3be&type=3#styles
UnityEditor.AssetPostprocessingInternal:PostprocessAllAssets (string[],string[],string[],string[],string[],bool)
```
I'm not familiar with it, so leave it as is. The basic behavior is working so maybe moving the sample to another Example repository would be a better option.

I hope it will be useful for your project!